### PR TITLE
Add Raportit page with date-range stats and DailyStats tracking

### DIFF
--- a/controllers/popup.controller.js
+++ b/controllers/popup.controller.js
@@ -1,9 +1,10 @@
 // controllers/popup.controller.js
 // Vastaa popup-toimintojen logiikasta
 
-const Popup = require('../models/Popup');
-const Image = require('../models/Image');
-const User = require('../models/User');
+const Popup      = require('../models/Popup');
+const Image      = require('../models/Image');
+const User       = require('../models/User');
+const DailyStats = require('../models/DailyStats');
 const { triggerWebhooks } = require('../utils/webhooks');
 
 const { bucket } = require('../firebase');
@@ -453,15 +454,24 @@ class PopupController {
   static async registerView(req, res) {
     try {
       const popupId = req.params.id;
-      
-      // Päivitä tilastot
+      const today = new Date().toISOString().slice(0, 10); // 'YYYY-MM-DD'
+
+      // Päivitä kumulatiiviset tilastot
       await Popup.findByIdAndUpdate(popupId, {
         $inc: { 'statistics.views': 1 },
         $set: { 'statistics.lastViewed': new Date() }
       });
 
+      // Päivitä päiväkohtaiset tilastot
       const popup = await Popup.findById(popupId).select('userId').lean();
-      if (popup) triggerWebhooks(popup.userId, 'view', { popupId });
+      if (popup) {
+        DailyStats.findOneAndUpdate(
+          { userId: popup.userId, popupId, date: today },
+          { $inc: { views: 1 } },
+          { upsert: true, new: true }
+        ).catch(() => {}); // ei blokkaa vastausta
+        triggerWebhooks(popup.userId, 'view', { popupId });
+      }
 
       res.status(200).json({ success: true });
     } catch (err) {
@@ -478,15 +488,24 @@ class PopupController {
   static async registerClick(req, res) {
     try {
       const popupId = req.params.id;
-      
-      // Päivitä tilastot
+      const today = new Date().toISOString().slice(0, 10); // 'YYYY-MM-DD'
+
+      // Päivitä kumulatiiviset tilastot
       await Popup.findByIdAndUpdate(popupId, {
         $inc: { 'statistics.clicks': 1 },
         $set: { 'statistics.lastClicked': new Date() }
       }, { new: true });
 
+      // Päivitä päiväkohtaiset tilastot
       const clickedPopup = await Popup.findById(popupId).select('userId').lean();
-      if (clickedPopup) triggerWebhooks(clickedPopup.userId, 'click', { popupId });
+      if (clickedPopup) {
+        DailyStats.findOneAndUpdate(
+          { userId: clickedPopup.userId, popupId, date: today },
+          { $inc: { clicks: 1 } },
+          { upsert: true, new: true }
+        ).catch(() => {}); // ei blokkaa vastausta
+        triggerWebhooks(clickedPopup.userId, 'click', { popupId });
+      }
 
       res.status(200).json({ success: true, message: 'Click registered' });
     } catch (err) {

--- a/controllers/reports.controller.js
+++ b/controllers/reports.controller.js
@@ -1,0 +1,287 @@
+// controllers/reports.controller.js
+// Raporttidata dashboardiin ja sähköpostilähetykseen
+
+const Popup      = require('../models/Popup');
+const Lead       = require('../models/Lead');
+const DailyStats = require('../models/DailyStats');
+const { sendMail } = require('../utils/email');
+
+// Rate limiting: max 3 raporttisähköpostia tunnissa per käyttäjä
+const emailCooldown = new Map();
+
+/**
+ * Muodostaa from/to -päivämäärärajat kyselyä varten.
+ * Palauttaa { fromDate: Date, toDate: Date, fromStr: string, toStr: string }
+ */
+function parseDateRange(fromQ, toQ) {
+  const toDate  = toQ   ? new Date(toQ   + 'T23:59:59.999Z') : new Date();
+  const fromDate = fromQ ? new Date(fromQ + 'T00:00:00.000Z') : new Date(0);
+  const toStr   = toDate.toISOString().slice(0, 10);
+  const fromStr = fromDate.toISOString().slice(0, 10);
+  return { fromDate, toDate, fromStr, toStr };
+}
+
+/**
+ * GET /api/reports
+ * Query: from, to, popupId, siteId
+ */
+exports.getReport = async (req, res) => {
+  try {
+    const userId = req.user._id;
+    const { fromDate, toDate, fromStr, toStr } = parseDateRange(req.query.from, req.query.to);
+    const { popupId, siteId } = req.query;
+
+    // Rakenna popup-suodatin
+    const popupFilter = { userId };
+    if (popupId) popupFilter._id = popupId;
+    if (siteId === '_none') popupFilter.siteId = null;
+    else if (siteId) popupFilter.siteId = siteId;
+
+    // Hae sopivat popupit (tarvitaan id-lista ja all-time summat)
+    const popups = await Popup.find(popupFilter)
+      .select('_id name elementType statistics siteId')
+      .lean();
+    const popupIds = popups.map(p => p._id);
+
+    if (!popupIds.length) {
+      return res.json({
+        period:   { views: 0, clicks: 0, leads: 0 },
+        allTime:  { views: 0, clicks: 0, leads: 0 },
+        topElements: [],
+        recentLeads: [],
+      });
+    }
+
+    // ── Jaksokohtaiset tilastot ────────────────────────────────────────────────
+    const [dailyAgg, periodLeads] = await Promise.all([
+      // Views + clicks DailyStats-kokoelmasta
+      DailyStats.aggregate([
+        { $match: { popupId: { $in: popupIds }, date: { $gte: fromStr, $lte: toStr } } },
+        { $group: { _id: null, views: { $sum: '$views' }, clicks: { $sum: '$clicks' } } },
+      ]),
+      // Liidit Lead-mallista
+      Lead.countDocuments({ userId, popupId: { $in: popupIds }, submittedAt: { $gte: fromDate, $lte: toDate } }),
+    ]);
+
+    const period = {
+      views:  dailyAgg[0]?.views  || 0,
+      clicks: dailyAgg[0]?.clicks || 0,
+      leads:  periodLeads,
+    };
+
+    // ── Kaikki-aikainen summa ─────────────────────────────────────────────────
+    const allTime = popups.reduce((acc, p) => {
+      acc.views  += p.statistics?.views  || 0;
+      acc.clicks += p.statistics?.clicks || 0;
+      acc.leads  += p.statistics?.leads  || 0;
+      return acc;
+    }, { views: 0, clicks: 0, leads: 0 });
+
+    // ── Top-elementit jaksolle ────────────────────────────────────────────────
+    // Aggregoi DailyStats per popup
+    const dailyPerPopup = await DailyStats.aggregate([
+      { $match: { popupId: { $in: popupIds }, date: { $gte: fromStr, $lte: toStr } } },
+      { $group: { _id: '$popupId', views: { $sum: '$views' }, clicks: { $sum: '$clicks' } } },
+    ]);
+    const dailyMap = Object.fromEntries(dailyPerPopup.map(d => [String(d._id), d]));
+
+    // Liidit per popup jaksolla
+    const leadsByPopup = await Lead.aggregate([
+      { $match: { userId, popupId: { $in: popupIds }, submittedAt: { $gte: fromDate, $lte: toDate } } },
+      { $group: { _id: '$popupId', leads: { $sum: 1 } } },
+    ]);
+    const leadsMap = Object.fromEntries(leadsByPopup.map(l => [String(l._id), l.leads]));
+
+    const topElements = popups
+      .filter(p => p.elementType !== 'stats_only')
+      .map(p => {
+        const d = dailyMap[String(p._id)] || {};
+        return {
+          _id:    p._id,
+          name:   p.name || 'Nimetön',
+          type:   p.elementType || 'popup',
+          views:  d.views  || 0,
+          clicks: d.clicks || 0,
+          leads:  leadsMap[String(p._id)] || 0,
+        };
+      })
+      .sort((a, b) => b.leads - a.leads || b.clicks - a.clicks || b.views - a.views)
+      .slice(0, 5);
+
+    // ── Viimeisimmät liidit jaksolla ──────────────────────────────────────────
+    const recentLeadsRaw = await Lead
+      .find({ userId, popupId: { $in: popupIds }, submittedAt: { $gte: fromDate, $lte: toDate } })
+      .sort({ submittedAt: -1 })
+      .limit(20)
+      .populate('popupId', 'name')
+      .lean();
+
+    const recentLeads = recentLeadsRaw.map(l => ({
+      popupName:   l.popupId?.name || 'Tuntematon',
+      data:        l.data || {},
+      submittedAt: l.submittedAt,
+    }));
+
+    res.json({ period, allTime, topElements, recentLeads });
+  } catch (err) {
+    console.error('[reports] getReport error:', err);
+    res.status(500).json({ message: 'Raportin haku epäonnistui', error: err.message });
+  }
+};
+
+/**
+ * POST /api/reports/email
+ * Body: { from, to, popupId, siteId }
+ */
+exports.emailReport = async (req, res) => {
+  try {
+    const userId = req.user._id;
+    const key    = String(userId);
+
+    // Rate limit: max 3 per tunti
+    const record = emailCooldown.get(key) || { count: 0, reset: Date.now() + 3600000 };
+    if (Date.now() > record.reset) { record.count = 0; record.reset = Date.now() + 3600000; }
+    if (record.count >= 3) {
+      const minLeft = Math.ceil((record.reset - Date.now()) / 60000);
+      return res.status(429).json({ message: `Odota ${minLeft} min ennen uutta raporttia.` });
+    }
+    record.count++;
+    emailCooldown.set(key, record);
+
+    const { from, to, popupId, siteId } = req.body;
+    const { fromDate, toDate, fromStr, toStr } = parseDateRange(from, to);
+
+    // Hae data (sama logiikka kuin getReport)
+    const popupFilter = { userId };
+    if (popupId) popupFilter._id = popupId;
+    if (siteId === '_none') popupFilter.siteId = null;
+    else if (siteId) popupFilter.siteId = siteId;
+
+    const popups = await Popup.find(popupFilter).select('_id name elementType statistics').lean();
+    const popupIds = popups.map(p => p._id);
+
+    const [dailyAgg, periodLeads, recentLeadsRaw] = await Promise.all([
+      DailyStats.aggregate([
+        { $match: { popupId: { $in: popupIds }, date: { $gte: fromStr, $lte: toStr } } },
+        { $group: { _id: null, views: { $sum: '$views' }, clicks: { $sum: '$clicks' } } },
+      ]),
+      Lead.countDocuments({ userId, popupId: { $in: popupIds }, submittedAt: { $gte: fromDate, $lte: toDate } }),
+      Lead.find({ userId, popupId: { $in: popupIds }, submittedAt: { $gte: fromDate, $lte: toDate } })
+        .sort({ submittedAt: -1 }).limit(10).populate('popupId', 'name').lean(),
+    ]);
+
+    const period  = { views: dailyAgg[0]?.views || 0, clicks: dailyAgg[0]?.clicks || 0, leads: periodLeads };
+    const allTime = popups.reduce((a, p) => {
+      a.views  += p.statistics?.views  || 0;
+      a.clicks += p.statistics?.clicks || 0;
+      a.leads  += p.statistics?.leads  || 0;
+      return a;
+    }, { views: 0, clicks: 0, leads: 0 });
+
+    const recentLeads = recentLeadsRaw.map(l => ({
+      popupName: l.popupId?.name || 'Tuntematon',
+      data: l.data || {},
+      submittedAt: l.submittedAt,
+    }));
+
+    // Muodosta aikaväli-label
+    const fmt = d => new Date(d).toLocaleDateString('fi-FI');
+    const label = from && to ? `${fmt(fromDate)}–${fmt(toDate)}` : from ? `${fmt(fromDate)} alkaen` : 'Kaikki aika';
+
+    // Rakenna HTML-sähköposti
+    const html = buildReportEmail(req.user, period, allTime, recentLeads, label);
+    const subject = `📊 Raportti: ${label} – UI Manager`;
+
+    const toEmail = req.user.emailNotifications?.notifyEmail?.trim() || req.user.email;
+    const ok = await sendMail(toEmail, subject, html);
+    if (!ok) throw new Error('Sähköpostin lähetys epäonnistui');
+
+    res.json({ ok: true, to: toEmail });
+  } catch (err) {
+    console.error('[reports] emailReport error:', err);
+    res.status(500).json({ message: err.message || 'Lähetys epäonnistui' });
+  }
+};
+
+// ─── HTML-sähköpostipohja ─────────────────────────────────────────────────────
+
+function esc(s) { return String(s || '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+
+function buildReportEmail(user, period, allTime, leads, label) {
+  const name = (user.displayName || 'Hei').split(' ')[0];
+
+  const statCell = (icon, val, label, bg = '#f8fafc') => `
+    <td style="text-align:center;padding:14px 8px;background:${bg};border-radius:10px">
+      <div style="font-size:20px;margin-bottom:2px">${icon}</div>
+      <div style="font-size:24px;font-weight:800;color:#0f172a">${val}</div>
+      <div style="font-size:11px;color:#64748b;margin-top:2px">${label}</div>
+    </td>`;
+
+  const leadsHtml = leads.length
+    ? `<div style="margin-top:24px">
+        <div style="font-size:14px;font-weight:700;color:#0f172a;margin-bottom:10px">📋 Viimeisimmät liidit (${leads.length} kpl)</div>
+        <table width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse">
+          ${leads.map(l => {
+            const preview = Object.values(l.data || {}).filter(Boolean).slice(0,2).join(' · ') || '(tyhjä)';
+            return `<tr>
+              <td style="padding:7px 10px;border-bottom:1px solid #f1f5f9;font-size:12px;color:#374151">${esc(preview)}</td>
+              <td style="padding:7px 10px;border-bottom:1px solid #f1f5f9;font-size:11px;color:#94a3b8;white-space:nowrap">${new Date(l.submittedAt).toLocaleDateString('fi-FI')}</td>
+            </tr>`;
+          }).join('')}
+        </table>
+      </div>` : '';
+
+  const body = `
+    <p style="font-size:15px;color:#374151;margin:0 0 20px">Hei ${esc(name)}! Tässä raporttisi ajalta <strong>${esc(label)}</strong>.</p>
+
+    <div style="font-size:13px;font-weight:700;color:#64748b;margin-bottom:8px;text-transform:uppercase;letter-spacing:0.05em">Valittu aikaväli</div>
+    <table width="100%" cellpadding="6" cellspacing="0" style="margin-bottom:20px">
+      <tr>
+        ${statCell('👁️', period.views,  'Näyttöä')}
+        <td width="8"></td>
+        ${statCell('🖱️', period.clicks, 'Klikkausta')}
+        <td width="8"></td>
+        ${statCell('📋', period.leads,  'Liidiä')}
+      </tr>
+    </table>
+
+    <div style="font-size:13px;font-weight:700;color:#64748b;margin-bottom:8px;text-transform:uppercase;letter-spacing:0.05em">Kaikki aika yhteensä</div>
+    <table width="100%" cellpadding="6" cellspacing="0" style="margin-bottom:8px">
+      <tr>
+        ${statCell('👁️', allTime.views,  'Näyttöä yhteensä', '#f1f5f9')}
+        <td width="8"></td>
+        ${statCell('🖱️', allTime.clicks, 'Klikkausta yhteensä', '#f1f5f9')}
+        <td width="8"></td>
+        ${statCell('📋', allTime.leads,  'Liidiä yhteensä', '#f1f5f9')}
+      </tr>
+    </table>
+
+    ${leadsHtml}
+
+    <div style="margin-top:24px">
+      <a href="${process.env.APP_URL || 'https://popupmanager.net'}/dashboard#reports"
+        style="display:inline-block;background:#1e40af;color:#fff;text-decoration:none;padding:12px 24px;border-radius:8px;font-size:14px;font-weight:600">
+        📊 Avaa Raportit-sivu →
+      </a>
+    </div>`;
+
+  // Minimal email wrapper
+  return `<!DOCTYPE html><html lang="fi"><head><meta charset="UTF-8"></head>
+<body style="margin:0;padding:0;background:#f1f5f9;font-family:'Segoe UI',Arial,sans-serif">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f1f5f9;padding:32px 16px">
+    <tr><td align="center">
+      <table width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%">
+        <tr><td style="background:#1e40af;border-radius:12px 12px 0 0;padding:20px 32px;text-align:center">
+          <span style="color:#fff;font-size:20px;font-weight:700">UI Manager</span>
+        </td></tr>
+        <tr><td style="background:#fff;border-radius:0 0 12px 12px;padding:32px;border:1px solid #e2e8f0;border-top:none">
+          ${body}
+        </td></tr>
+        <tr><td style="padding:20px 0;text-align:center;font-size:12px;color:#94a3b8">
+          UI Manager · <a href="${process.env.APP_URL || 'https://popupmanager.net'}/dashboard#settings" style="color:#94a3b8">Hallitse ilmoituksia</a>
+        </td></tr>
+      </table>
+    </td></tr>
+  </table>
+</body></html>`;
+}

--- a/dashboard.html
+++ b/dashboard.html
@@ -25,6 +25,9 @@
         <i class="fa fa-layer-group"></i> Omat elementit
       </a>
       <div class="nav-section" style="margin-top:12px">Hallinta</div>
+      <a href="#reports" class="nav-link" data-view="reports">
+        <i class="fa fa-chart-line"></i> Raportit
+      </a>
       <a href="#analytics" class="nav-link" data-view="analytics">
         <i class="fa fa-chart-bar"></i> Tilastot
       </a>
@@ -117,6 +120,11 @@
         <div id="quota-bar" style="margin-top:16px"></div>
         <div id="elements-filter-bar" style="margin-top:8px"></div>
         <div id="elements-grid" class="elements-grid" style="margin-top:8px"></div>
+      </div>
+
+      <!-- Raportit -->
+      <div id="view-reports" style="display:none">
+        <div id="reports-content"></div>
       </div>
 
       <!-- Tilastot -->

--- a/js/dashboard/dashboard-main.js
+++ b/js/dashboard/dashboard-main.js
@@ -7,6 +7,7 @@ import { initAnalyticsPage }  from './analytics-page.js';
 import { initHelpPanel }      from './help-panel.js';
 import { initLeadsPanel }     from './leads-panel.js';
 import { initImageLibraryPanel } from './image-library-panel.js';
+import { initReportsPage }    from './reports-page.js';
 
 let currentView = 'elements';
 
@@ -46,6 +47,7 @@ async function init() {
   initElementList(user);
   initTemplateLibrary();
   initAnalyticsPage();
+  initReportsPage();
   initHelpPanel();
   initLeadsPanel();
   initImageLibraryPanel();
@@ -79,7 +81,7 @@ export function showView(name) {
     a.classList.toggle('active', a.dataset.view === name || a.getAttribute('href') === '#' + name);
   });
 
-  const titles = { elements: 'Omat elementit', analytics: 'Tilastot', settings: 'Asennuskoodi', help: 'Ohjeet', leads: 'Liidit' };
+  const titles = { elements: 'Omat elementit', reports: 'Raportit', analytics: 'Tilastot', settings: 'Asennuskoodi', help: 'Ohjeet', leads: 'Liidit' };
   const titleEl = document.getElementById('topbar-title');
   if (titleEl) titleEl.textContent = titles[name] || 'UI Manager';
 }

--- a/js/dashboard/reports-page.js
+++ b/js/dashboard/reports-page.js
@@ -1,0 +1,371 @@
+// js/dashboard/reports-page.js
+// Raportit-sivu: aikavälisuodatus, tilastokortit, top-elementit, liidit
+
+import { showToast } from './dashboard-main.js';
+
+let cachedSites   = [];
+let cachedPopups  = [];
+let currentRange  = 'week';  // 'today' | 'week' | 'month' | 'all' | 'custom'
+let customFrom    = '';
+let customTo      = '';
+let filterPopupId = '';
+let filterSiteId  = '';
+let initialized   = false;
+
+// ─── Julkinen init ────────────────────────────────────────────────────────────
+
+export function initReportsPage() {
+  // Kuuntele näkymän vaihtoa
+  window.addEventListener('hashchange', () => {
+    if (window.location.hash === '#reports') onEnter();
+  });
+  if (window.location.hash === '#reports') onEnter();
+}
+
+async function onEnter() {
+  const container = document.getElementById('reports-content');
+  if (!container) return;
+
+  if (!initialized) {
+    // Lataa sivustot + popupit suodattimia varten
+    await Promise.all([loadSites(), loadPopups()]);
+    initialized = true;
+  }
+
+  renderShell(container);
+  loadReport();
+}
+
+// ─── Data-lataus ─────────────────────────────────────────────────────────────
+
+async function loadSites() {
+  try {
+    const r = await fetch('/api/sites');
+    if (r.ok) cachedSites = await r.json();
+  } catch {}
+}
+
+async function loadPopups() {
+  try {
+    const r = await fetch('/api/popups');
+    if (r.ok) cachedPopups = (await r.json()).filter(p => p.elementType !== 'stats_only');
+  } catch {}
+}
+
+function getDateRange() {
+  const now  = new Date();
+  const pad  = n => String(n).padStart(2, '0');
+  const ymd  = d => `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}`;
+  const today = ymd(now);
+
+  if (currentRange === 'today') return { from: today, to: today };
+  if (currentRange === 'week') {
+    const day = now.getDay() || 7;
+    const mon = new Date(now); mon.setDate(now.getDate() - day + 1);
+    return { from: ymd(mon), to: today };
+  }
+  if (currentRange === 'month') {
+    const first = new Date(now.getFullYear(), now.getMonth(), 1);
+    return { from: ymd(first), to: today };
+  }
+  if (currentRange === 'all') return { from: '', to: '' };
+  return { from: customFrom, to: customTo };
+}
+
+async function loadReport() {
+  const container = document.getElementById('reports-content');
+  if (!container) return;
+
+  const resultsEl = document.getElementById('report-results');
+  if (resultsEl) resultsEl.innerHTML = loadingHTML();
+
+  const { from, to } = getDateRange();
+  const params = new URLSearchParams();
+  if (from) params.set('from', from);
+  if (to)   params.set('to',   to);
+  if (filterPopupId) params.set('popupId', filterPopupId);
+  if (filterSiteId)  params.set('siteId',  filterSiteId);
+
+  try {
+    const r = await fetch('/api/reports?' + params.toString());
+    if (!r.ok) throw new Error('Virhe');
+    const data = await r.json();
+    renderResults(data, from, to);
+  } catch {
+    if (resultsEl) resultsEl.innerHTML = `<div style="color:#ef4444;padding:24px">Raportin lataus epäonnistui.</div>`;
+  }
+}
+
+// ─── Rakenne ──────────────────────────────────────────────────────────────────
+
+function renderShell(container) {
+  const sitesOpts  = cachedSites.map(s =>
+    `<option value="${s._id}">${esc(s.name)}${s.domain ? ' ('+esc(s.domain)+')' : ''}</option>`
+  ).join('');
+  const popupOpts  = cachedPopups.map(p =>
+    `<option value="${p._id}">${esc(p.name)}</option>`
+  ).join('');
+
+  container.innerHTML = `
+    <div style="max-width:960px">
+
+      <!-- Otsikkorivi -->
+      <div style="display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:12px;margin-bottom:20px">
+        <div>
+          <h2 style="font-size:20px;font-weight:800;color:#0f172a;margin:0">Raportit</h2>
+          <p style="font-size:13px;color:#64748b;margin:4px 0 0">Näytöt, klikkaukset ja liidit valitulta ajanjaksolta</p>
+        </div>
+        <button id="rpt-email-btn" class="btn btn-secondary btn-sm" style="gap:6px">
+          <i class="fa fa-envelope"></i> Lähetä sähköpostiin
+        </button>
+      </div>
+
+      <!-- Aikavälipalkit -->
+      <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-bottom:16px">
+        ${['today','week','month','all','custom'].map(k => {
+          const labels = { today:'Tänään', week:'Tämä viikko', month:'Tämä kuukausi', all:'Kaikki aika', custom:'Muokkaa...' };
+          const active = currentRange === k;
+          return `<button class="rpt-range-btn" data-range="${k}"
+            style="padding:7px 14px;border:2px solid ${active?'#3b82f6':'#e2e8f0'};border-radius:20px;
+            background:${active?'#eff6ff':'#fff'};color:${active?'#1d4ed8':'#374151'};
+            font-size:13px;font-weight:${active?'700':'500'};cursor:pointer;transition:all 0.15s">
+            ${labels[k]}
+          </button>`;
+        }).join('')}
+      </div>
+
+      <!-- Muokkaa-aikaväli (piilotettu) -->
+      <div id="rpt-custom-row" style="display:${currentRange==='custom'?'flex':'none'};gap:12px;align-items:center;flex-wrap:wrap;margin-bottom:16px;background:#f8fafc;border:1px solid #e2e8f0;border-radius:10px;padding:12px 16px">
+        <div style="display:flex;align-items:center;gap:8px">
+          <label style="font-size:12px;font-weight:600;color:#374151">Alkaen</label>
+          <input type="date" id="rpt-from" value="${customFrom}" style="padding:7px 10px;border:1px solid #d1d5db;border-radius:7px;font-size:13px">
+        </div>
+        <div style="display:flex;align-items:center;gap:8px">
+          <label style="font-size:12px;font-weight:600;color:#374151">Saakka</label>
+          <input type="date" id="rpt-to" value="${customTo}" style="padding:7px 10px;border:1px solid #d1d5db;border-radius:7px;font-size:13px">
+        </div>
+        <button id="rpt-apply-custom" class="btn btn-primary btn-sm">Hae</button>
+      </div>
+
+      <!-- Suodattimet -->
+      <div style="display:flex;gap:10px;flex-wrap:wrap;margin-bottom:20px">
+        ${cachedSites.length ? `
+        <select id="rpt-site-filter" style="font-size:13px;padding:7px 12px;border:1px solid #e2e8f0;border-radius:8px;background:#fff;color:#374151;cursor:pointer">
+          <option value="">Kaikki sivustot</option>
+          ${sitesOpts}
+          <option value="_none">– Ei sivustoa –</option>
+        </select>` : ''}
+        ${cachedPopups.length ? `
+        <select id="rpt-popup-filter" style="font-size:13px;padding:7px 12px;border:1px solid #e2e8f0;border-radius:8px;background:#fff;color:#374151;cursor:pointer">
+          <option value="">Kaikki elementit</option>
+          ${popupOpts}
+        </select>` : ''}
+      </div>
+
+      <!-- Tulokset -->
+      <div id="report-results">
+        ${loadingHTML()}
+      </div>
+
+    </div>`;
+
+  // Event listeners
+  container.querySelectorAll('.rpt-range-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      currentRange = btn.dataset.range;
+      renderShell(container);
+      if (currentRange !== 'custom') loadReport();
+    });
+  });
+
+  document.getElementById('rpt-apply-custom')?.addEventListener('click', () => {
+    customFrom = document.getElementById('rpt-from')?.value || '';
+    customTo   = document.getElementById('rpt-to')?.value   || '';
+    loadReport();
+  });
+
+  document.getElementById('rpt-site-filter')?.addEventListener('change', e => {
+    filterSiteId = e.target.value;
+    loadReport();
+  });
+  document.getElementById('rpt-popup-filter')?.addEventListener('change', e => {
+    filterPopupId = e.target.value;
+    loadReport();
+  });
+
+  document.getElementById('rpt-email-btn')?.addEventListener('click', sendReportEmail);
+
+  // Palauta suodatinvalinnat
+  if (filterSiteId)  { const el = document.getElementById('rpt-site-filter');  if (el) el.value = filterSiteId; }
+  if (filterPopupId) { const el = document.getElementById('rpt-popup-filter'); if (el) el.value = filterPopupId; }
+}
+
+// ─── Tulokset ─────────────────────────────────────────────────────────────────
+
+function renderResults(data, from, to) {
+  const el = document.getElementById('report-results');
+  if (!el) return;
+
+  const { period, allTime, topElements, recentLeads } = data;
+  const ctr = period.views > 0 ? ((period.clicks / period.views) * 100).toFixed(1) : '0.0';
+  const allCtr = allTime.views > 0 ? ((allTime.clicks / allTime.views) * 100).toFixed(1) : '0.0';
+
+  const periodLabel = currentRange === 'all' ? 'Kaikki aika' :
+    currentRange === 'today' ? 'Tänään' :
+    currentRange === 'week'  ? 'Tämä viikko' :
+    currentRange === 'month' ? 'Tämä kuukausi' :
+    (from && to ? `${fmtDate(from)} – ${fmtDate(to)}` : 'Valittu aikaväli');
+
+  el.innerHTML = `
+    <!-- Jakso-kortit -->
+    <div style="margin-bottom:8px">
+      <div style="font-size:11px;font-weight:700;color:#94a3b8;text-transform:uppercase;letter-spacing:0.07em;margin-bottom:10px">
+        ${esc(periodLabel)}
+      </div>
+      <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:12px;margin-bottom:20px">
+        ${statCard('👁️', period.views,  'Näyttöä',     '#fff', '#3b82f6')}
+        ${statCard('🖱️', period.clicks, 'Klikkausta',  '#fff', '#3b82f6')}
+        ${statCard('📋', period.leads,  'Liidiä',       '#fff', '#3b82f6')}
+        ${statCard('📈', ctr + '%',     'CTR',          '#fff', '#3b82f6')}
+      </div>
+    </div>
+
+    <!-- Kaikki-aika-kortit -->
+    <div style="margin-bottom:24px">
+      <div style="font-size:11px;font-weight:700;color:#94a3b8;text-transform:uppercase;letter-spacing:0.07em;margin-bottom:10px">
+        Kaikki aika yhteensä
+      </div>
+      <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:12px">
+        ${statCard('👁️', allTime.views,  'Näyttöä',    '#f8fafc', '#94a3b8')}
+        ${statCard('🖱️', allTime.clicks, 'Klikkausta', '#f8fafc', '#94a3b8')}
+        ${statCard('📋', allTime.leads,  'Liidiä',      '#f8fafc', '#94a3b8')}
+        ${statCard('📈', allCtr + '%',   'CTR',         '#f8fafc', '#94a3b8')}
+      </div>
+    </div>
+
+    <!-- Kaksi saraketta: top-elementit + liidit -->
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:20px;align-items:start">
+
+      <!-- Top-elementit -->
+      <div style="background:#fff;border:1px solid #e2e8f0;border-radius:12px;overflow:hidden">
+        <div style="padding:16px 20px;border-bottom:1px solid #f1f5f9;display:flex;align-items:center;gap:8px">
+          <span style="font-size:16px">🏆</span>
+          <span style="font-size:14px;font-weight:700;color:#0f172a">Top elementit</span>
+          <span style="font-size:11px;color:#94a3b8;margin-left:auto">${esc(periodLabel)}</span>
+        </div>
+        ${topElements.length ? `
+        <table style="width:100%;border-collapse:collapse">
+          <thead>
+            <tr style="background:#f8fafc">
+              <th style="padding:10px 16px;font-size:11px;font-weight:600;color:#94a3b8;text-align:left">Nimi</th>
+              <th style="padding:10px 8px;font-size:11px;font-weight:600;color:#94a3b8;text-align:right">Näytöt</th>
+              <th style="padding:10px 8px;font-size:11px;font-weight:600;color:#94a3b8;text-align:right">Klikkaukset</th>
+              <th style="padding:10px 16px;font-size:11px;font-weight:600;color:#94a3b8;text-align:right">Liidit</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${topElements.map((el, i) => `
+              <tr style="border-top:1px solid #f1f5f9;${i%2===1?'background:#fafbfc':''}">
+                <td style="padding:10px 16px">
+                  <div style="font-size:13px;font-weight:600;color:#0f172a">${esc(el.name)}</div>
+                  <div style="font-size:11px;color:#94a3b8">${typeBadge(el.type)}</div>
+                </td>
+                <td style="padding:10px 8px;font-size:13px;color:#374151;text-align:right">${el.views}</td>
+                <td style="padding:10px 8px;font-size:13px;color:#374151;text-align:right">${el.clicks}</td>
+                <td style="padding:10px 16px;font-size:13px;font-weight:700;color:#1d4ed8;text-align:right">${el.leads}</td>
+              </tr>`).join('')}
+          </tbody>
+        </table>` : `
+        <div style="padding:32px;text-align:center;color:#94a3b8;font-size:13px">
+          Ei dataa valitulle jaksolle.<br>
+          <span style="font-size:12px">Data kertyy tästä päivästä alkaen.</span>
+        </div>`}
+      </div>
+
+      <!-- Viimeisimmät liidit -->
+      <div style="background:#fff;border:1px solid #e2e8f0;border-radius:12px;overflow:hidden">
+        <div style="padding:16px 20px;border-bottom:1px solid #f1f5f9;display:flex;align-items:center;gap:8px">
+          <span style="font-size:16px">📋</span>
+          <span style="font-size:14px;font-weight:700;color:#0f172a">Viimeisimmät liidit</span>
+          ${recentLeads.length ? `<span style="font-size:11px;color:#3b82f6;font-weight:600;margin-left:auto;background:#eff6ff;padding:2px 8px;border-radius:10px">${recentLeads.length} kpl</span>` : ''}
+        </div>
+        ${recentLeads.length ? `
+        <div style="max-height:420px;overflow-y:auto">
+          ${recentLeads.map(l => {
+            const preview = Object.values(l.data || {}).filter(Boolean).slice(0, 2).join(' · ') || '(tyhjä)';
+            return `<div style="padding:12px 16px;border-bottom:1px solid #f8fafc">
+              <div style="display:flex;justify-content:space-between;align-items:flex-start;gap:8px">
+                <div style="flex:1;min-width:0">
+                  <div style="font-size:12px;font-weight:600;color:#64748b;margin-bottom:2px">${esc(l.popupName)}</div>
+                  <div style="font-size:13px;color:#0f172a;word-break:break-word">${esc(preview)}</div>
+                </div>
+                <div style="font-size:11px;color:#94a3b8;white-space:nowrap;flex-shrink:0">${fmtDate(l.submittedAt)}</div>
+              </div>
+            </div>`;
+          }).join('')}
+        </div>` : `
+        <div style="padding:32px;text-align:center;color:#94a3b8;font-size:13px">
+          Ei liidejä valitulle jaksolle.
+        </div>`}
+      </div>
+
+    </div>`;
+}
+
+// ─── Sähköpostilähetys ────────────────────────────────────────────────────────
+
+async function sendReportEmail() {
+  const btn = document.getElementById('rpt-email-btn');
+  if (btn) { btn.disabled = true; btn.innerHTML = '<i class="fa fa-spinner fa-spin"></i> Lähetetään...'; }
+
+  const { from, to } = getDateRange();
+  try {
+    const r = await fetch('/api/reports/email', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ from, to, popupId: filterPopupId, siteId: filterSiteId }),
+    });
+    const data = await r.json();
+    if (!r.ok) throw new Error(data.message || 'Virhe');
+    showToast(`✓ Raportti lähetetty osoitteeseen ${data.to}`);
+  } catch (e) {
+    showToast(e.message || 'Lähetys epäonnistui', 'error');
+  } finally {
+    if (btn) { btn.disabled = false; btn.innerHTML = '<i class="fa fa-envelope"></i> Lähetä sähköpostiin'; }
+  }
+}
+
+// ─── Apufunktiot ──────────────────────────────────────────────────────────────
+
+function statCard(icon, value, label, bg, accentColor) {
+  return `
+    <div style="background:${bg};border:1px solid #e2e8f0;border-radius:12px;padding:18px 16px;
+      box-shadow:0 1px 3px rgba(0,0,0,0.05);transition:transform 0.15s"
+      onmouseenter="this.style.transform='translateY(-2px)'"
+      onmouseleave="this.style.transform=''">
+      <div style="font-size:22px;margin-bottom:6px">${icon}</div>
+      <div style="font-size:28px;font-weight:800;color:#0f172a;line-height:1">${value}</div>
+      <div style="font-size:12px;color:#64748b;margin-top:5px;font-weight:500">${label}</div>
+    </div>`;
+}
+
+const TYPE_LABELS = {
+  sticky_bar: 'Sticky Bar', fab: 'Floating Button',
+  slide_in: 'Slide-in', popup: 'Popup', lead_form: 'Lead Form',
+};
+function typeBadge(type) { return TYPE_LABELS[type] || type; }
+
+function fmtDate(d) {
+  if (!d) return '';
+  return new Date(d).toLocaleDateString('fi-FI');
+}
+
+function loadingHTML() {
+  return `<div style="display:flex;align-items:center;gap:10px;color:#94a3b8;padding:32px 0">
+    <i class="fa fa-spinner fa-spin"></i> <span>Ladataan...</span>
+  </div>`;
+}
+
+function esc(s) {
+  return String(s || '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+}

--- a/models/DailyStats.js
+++ b/models/DailyStats.js
@@ -1,0 +1,19 @@
+// models/DailyStats.js
+// Päiväkohtaiset näyttö- ja klikkausmäärät elementeittäin
+
+const mongoose = require('mongoose');
+
+const DailyStatsSchema = new mongoose.Schema({
+  userId:  { type: mongoose.Schema.Types.ObjectId, ref: 'User',  required: true },
+  popupId: { type: mongoose.Schema.Types.ObjectId, ref: 'Popup', required: true },
+  date:    { type: String, required: true }, // 'YYYY-MM-DD'
+  views:   { type: Number, default: 0 },
+  clicks:  { type: Number, default: 0 },
+}, { versionKey: false });
+
+// Compound-indeksit nopeisiin haku- ja aggregaatiokyselyihin
+DailyStatsSchema.index({ userId: 1, date: 1 });
+DailyStatsSchema.index({ popupId: 1, date: 1 });
+DailyStatsSchema.index({ userId: 1, popupId: 1, date: 1 }, { unique: true });
+
+module.exports = mongoose.model('DailyStats', DailyStatsSchema);

--- a/routes/reports.routes.js
+++ b/routes/reports.routes.js
@@ -1,0 +1,9 @@
+// routes/reports.routes.js
+const express = require('express');
+const router  = express.Router();
+const ReportsController = require('../controllers/reports.controller');
+
+router.get('/',       ReportsController.getReport);
+router.post('/email', ReportsController.emailReport);
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -15,11 +15,12 @@ const connectDB = require('./db');
 const { swaggerDocs } = require('./swagger');
 
 // Reittien tuonti
-const authRoutes = require('./routes/auth.routes');
-const userRoutes = require('./routes/user.routes');
-const popupRoutes = require('./routes/popup.routes');
-const imageRoutes = require('./routes/image.routes');
-const adminRoutes = require('./routes/admin.routes');
+const authRoutes    = require('./routes/auth.routes');
+const userRoutes    = require('./routes/user.routes');
+const popupRoutes   = require('./routes/popup.routes');
+const imageRoutes   = require('./routes/image.routes');
+const adminRoutes   = require('./routes/admin.routes');
+const reportsRoutes = require('./routes/reports.routes');
 
 // Middleware
 const authMiddleware = require('./middleware/auth.middleware');
@@ -244,6 +245,7 @@ app.get('/testisivu', (req, res) => {
 app.use('/auth', authRoutes);
 app.use('/api/user', userRoutes);
 app.use('/api/popups', authMiddleware.isUser, popupRoutes);
+app.use('/api/reports', authMiddleware.isUser, reportsRoutes);
 app.use('/api/upload', authMiddleware.isUser, imageRoutes);
 app.use('/api/images', authMiddleware.isUser, imageRoutes);
 app.use('/api/admin', authMiddleware.isAdmin, adminRoutes);

--- a/utils/email-templates.js
+++ b/utils/email-templates.js
@@ -131,21 +131,32 @@ function buildWeeklyReport(user, stats, topEls, leads, weekLabel) {
     return Math.round(((current - prev) / prev) * 100);
   }
 
-  const statBox = (icon, label, value, change) => `
-    <td style="text-align:center;padding:16px 8px;background:#f8fafc;border-radius:10px">
+  const statBox = (icon, label, value, change, bg = '#f8fafc') => `
+    <td style="text-align:center;padding:16px 8px;background:${bg};border-radius:10px">
       <div style="font-size:22px;margin-bottom:4px">${icon}</div>
       <div style="font-size:26px;font-weight:800;color:#0f172a">${value}</div>
       <div style="font-size:12px;color:#64748b;margin-top:2px">${label}${delta(change)}</div>
     </td>`;
 
   const statsRow = `
+    <div style="font-size:11px;font-weight:700;color:#94a3b8;text-transform:uppercase;letter-spacing:0.07em;margin-bottom:8px">Tällä viikolla</div>
+    <table width="100%" cellpadding="6" cellspacing="0" style="margin-bottom:16px">
+      <tr>
+        ${statBox('👁️', 'Näyttöä', stats.views)}
+        <td width="8"></td>
+        ${statBox('🖱️', 'Klikkausta', stats.clicks)}
+        <td width="8"></td>
+        ${statBox('📋', 'Liidiä', stats.leads, pct(stats.leads, stats.prevLeads))}
+      </tr>
+    </table>
+    <div style="font-size:11px;font-weight:700;color:#94a3b8;text-transform:uppercase;letter-spacing:0.07em;margin-bottom:8px">Kaikki aika yhteensä</div>
     <table width="100%" cellpadding="6" cellspacing="0">
       <tr>
-        ${statBox('👁️', 'Näyttöä yhteensä', stats.views)}
+        ${statBox('👁️', 'Näyttöä yhteensä', stats.allViews || 0, null, '#f1f5f9')}
         <td width="8"></td>
-        ${statBox('🖱️', 'Klikkausta yhteensä', stats.clicks)}
+        ${statBox('🖱️', 'Klikkausta yhteensä', stats.allClicks || 0, null, '#f1f5f9')}
         <td width="8"></td>
-        ${statBox('📋', 'Liidiä viikolla', stats.leads, pct(stats.leads, stats.prevLeads))}
+        ${statBox('📋', 'Liidiä yhteensä', stats.allLeads || 0, null, '#f1f5f9')}
       </tr>
     </table>`;
 

--- a/utils/weekly-report.js
+++ b/utils/weekly-report.js
@@ -1,9 +1,10 @@
 // utils/weekly-report.js
 // Viikkoraportin generointi ja lähetys kaikille käyttäjille
 
-const User  = require('../models/User');
-const Popup = require('../models/Popup');
-const Lead  = require('../models/Lead');
+const User       = require('../models/User');
+const Popup      = require('../models/Popup');
+const Lead       = require('../models/Lead');
+const DailyStats = require('../models/DailyStats');
 const { sendMail } = require('./email');
 const { buildWeeklyReport } = require('./email-templates');
 
@@ -48,21 +49,38 @@ function getWeekRanges() {
  * @returns {{ views, clicks, leads }}
  */
 async function getStatsForPeriod(userId, from, to) {
-  // Popupit eivät tallenna päivittäisiä tilastoja – käytetään Lead-mallia liideille
-  // ja Popup.statistics:ssa olevaa kokonaismäärää vertailuun ei voi käyttää ajalta,
-  // joten leads lasketaan tarkasti Lead-mallista.
-  // Views + clicks kerätään statistiikasta (kumulatiivisia – paras saatavilla oleva data)
+  // Muodosta päivämäärästring-raja DailyStats-kyselyä varten
+  const fromStr = from.toISOString().slice(0, 10);
+  const toStr   = to.toISOString().slice(0, 10);
 
+  const [dailyAgg, leads] = await Promise.all([
+    // Jaksokohtaiset views + clicks DailyStats-kokoelmasta
+    DailyStats.aggregate([
+      { $match: { userId, date: { $gte: fromStr, $lte: toStr } } },
+      { $group: { _id: null, views: { $sum: '$views' }, clicks: { $sum: '$clicks' } } },
+    ]),
+    // Liidit Lead-mallista (tarkka timestamp-suodatus)
+    Lead.countDocuments({ userId, submittedAt: { $gte: from, $lte: to } }),
+  ]);
+
+  return {
+    views:  dailyAgg[0]?.views  || 0,
+    clicks: dailyAgg[0]?.clicks || 0,
+    leads,
+  };
+}
+
+/**
+ * Hakee kaikki-aikaisen kokonaissumman käyttäjän kaikista elementeistä.
+ */
+async function getAllTimeStats(userId) {
   const popups = await Popup.find({ userId }).select('statistics').lean();
-  const leads = await Lead.countDocuments({ userId, submittedAt: { $gte: from, $lte: to } });
-
-  // Koska per-päivä view/click-logia ei vielä ole, palautetaan kumulatiivinen summa
-  // (sama luku molemmille periodeille) – delta on 0 mutta leads on tarkka.
-  // Tämä on paras mahdollinen ilman aikasarjatietokantaa.
-  const views  = popups.reduce((s, p) => s + (p.statistics?.views  || 0), 0);
-  const clicks = popups.reduce((s, p) => s + (p.statistics?.clicks || 0), 0);
-
-  return { views, clicks, leads };
+  return popups.reduce((acc, p) => {
+    acc.views  += p.statistics?.views  || 0;
+    acc.clicks += p.statistics?.clicks || 0;
+    acc.leads  += p.statistics?.leads  || 0;
+    return acc;
+  }, { views: 0, clicks: 0, leads: 0 });
 }
 
 /**
@@ -129,17 +147,23 @@ async function sendWeeklyReports() {
       const toEmail = user.emailNotifications?.notifyEmail?.trim() || user.email;
       if (!toEmail) continue;
 
-      // Tilastot tältä viikolta ja edelliseltä (vain leads on viikkokohtainen)
-      const [thisPeriod, prevPeriod] = await Promise.all([
+      // Tilastot tältä viikolta, edelliseltä ja kaikki-aikainen
+      const [thisPeriod, prevPeriod, allTime] = await Promise.all([
         getStatsForPeriod(user._id, lastMonday, lastSunday),
         getStatsForPeriod(user._id, prevMonday, prevSunday),
+        getAllTimeStats(user._id),
       ]);
 
       const stats = {
+        // Jaksokohtaiset (viikko)
         views:     thisPeriod.views,
         clicks:    thisPeriod.clicks,
         leads:     thisPeriod.leads,
         prevLeads: prevPeriod.leads,
+        // Kaikki aika
+        allViews:  allTime.views,
+        allClicks: allTime.clicks,
+        allLeads:  allTime.leads,
       };
 
       // Skipata jos viikolla ei tullut yhtään liidiä


### PR DESCRIPTION
- New DailyStats model: tracks views/clicks per day per element
- registerView/registerClick now upsert into DailyStats (non-blocking)
- New /api/reports endpoint: period stats + all-time totals + top elements + leads
- New /api/reports/email: sends formatted report to user's email (rate limited)
- New Raportit dashboard page: date presets, site/element filters, stat cards
- Weekly report email now shows both weekly period stats AND all-time totals
- Reports sidebar nav link added